### PR TITLE
Fixes Issue-2- BasicProperties can be null.

### DIFF
--- a/config/RabbitMQSourceConnector.properties
+++ b/config/RabbitMQSourceConnector.properties
@@ -6,4 +6,4 @@ rabbitmq.automatic.recovery.enabled=true
 rabbitmq.network.recovery.interval.ms=10000
 rabbitmq.topology.recovery.enabled=true
 rabbitmq.queue=test
-kafka.topic=rabbitmq.${envelope["routingKey"]}
+kafka.topic=rabbitmq.test

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <version>0.10.2.0-cp1</version>
   </parent>
   <artifactId>kafka-connect-rabbitmq</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
   <name>kafka-connect-rabbitmq</name>
   <description>A Kafka Connect connector receiving data from rabbitmq.</description>
   <url>https://github.com/jcustenborder/kafka-connect-rabbitmq</url>

--- a/src/main/java/com/github/jcustenborder/kafka/connect/rabbitmq/MessageConverter.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/rabbitmq/MessageConverter.java
@@ -111,6 +111,7 @@ class MessageConverter {
 
   static final Schema SCHEMA_BASIC_PROPERTIES = SchemaBuilder.struct()
       .name("com.github.jcustenborder.kafka.connect.rabbitmq.BasicProperties")
+      .optional()
       .doc("Corresponds to the [BasicProperties](https://www.rabbitmq.com/releases/rabbitmq-java-client/current-javadoc/com/rabbitmq/client/BasicProperties.html)")
       .field(
           FIELD_BASIC_PROPERTIES_CONTENTTYPE,
@@ -211,6 +212,11 @@ class MessageConverter {
   }
 
   static Struct basicProperties(BasicProperties basicProperties) {
+    if (null == basicProperties) {
+      log.trace("basicProperties() - basicProperties is null.");
+      return null;
+    }
+
     Map<String, Struct> headers = headers(basicProperties);
     return new Struct(SCHEMA_BASIC_PROPERTIES)
         .put(FIELD_BASIC_PROPERTIES_CONTENTTYPE, basicProperties.getContentType())

--- a/src/test/java/com/github/jcustenborder/kafka/connect/rabbitmq/MessageConverterTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/rabbitmq/MessageConverterTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import static com.github.jcustenborder.kafka.connect.utils.AssertStruct.assertStruct;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
@@ -56,6 +57,11 @@ public class MessageConverterTest {
     assertField(input.isRedeliver(), actual, MessageConverter.FIELD_ENVELOPE_ISREDELIVER);
   }
 
+  @Test
+  public void basicPropertiesNull() {
+    Struct basicProperties = MessageConverter.basicProperties(null);
+    assertNull(basicProperties);
+  }
 
   @Test
   public void headers() {


### PR DESCRIPTION
… not include it are properly processed. Removed `${envelope["routingKey"]}` from the example. It's a potentially poor choice for a topic name.