### PR TITLE
add message key nullable option

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/rabbitmq/RabbitMQSourceConnectorConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/rabbitmq/RabbitMQSourceConnectorConfig.java
@@ -27,6 +27,9 @@ class RabbitMQSourceConnectorConfig extends RabbitMQConnectorConfig {
   public static final String TOPIC_CONF = "kafka.topic";
   static final String TOPIC_DOC = "Kafka topic to write the messages to.";
 
+  public static final String PARTITION_KEY_NULL_CONF = "kafka.partition.key.null";
+  static final String PARTITION_KEY_NULL_DOC = "True if the message key should be null.";
+
   public static final String QUEUE_CONF = "rabbitmq.queue";
   static final String QUEUE_DOC = "rabbitmq.queue";
 
@@ -43,12 +46,14 @@ class RabbitMQSourceConnectorConfig extends RabbitMQConnectorConfig {
   public final List<String> queues;
   public final int prefetchCount;
   public final boolean prefetchGlobal;
+  public final boolean partitionKeyNull;
 
   public RabbitMQSourceConnectorConfig(Map<String, String> settings) {
     super(config(), settings);
 
     final String kafkaTopicFormat = this.getString(TOPIC_CONF);
     this.kafkaTopic = new StructTemplate();
+    this.partitionKeyNull = this.getBoolean(PARTITION_KEY_NULL_CONF);
     this.kafkaTopic.addTemplate(KAFKA_TOPIC_TEMPLATE, kafkaTopicFormat);
     this.queues = this.getList(QUEUE_CONF);
     this.prefetchCount = this.getInt(PREFETCH_COUNT_CONF);
@@ -58,6 +63,7 @@ class RabbitMQSourceConnectorConfig extends RabbitMQConnectorConfig {
   public static ConfigDef config() {
     return RabbitMQConnectorConfig.config()
         .define(TOPIC_CONF, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, TOPIC_DOC)
+        .define(PARTITION_KEY_NULL_CONF, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM, PARTITION_KEY_NULL_DOC)
         .define(PREFETCH_COUNT_CONF, ConfigDef.Type.INT, 0, ConfigDef.Importance.MEDIUM, PREFETCH_COUNT_DOC)
         .define(PREFETCH_GLOBAL_CONF, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.MEDIUM, PREFETCH_GLOBAL_DOC)
         .define(QUEUE_CONF, ConfigDef.Type.LIST, ConfigDef.Importance.HIGH, QUEUE_DOC);

--- a/src/main/java/com/github/jcustenborder/kafka/connect/rabbitmq/SourceRecordBuilder.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/rabbitmq/SourceRecordBuilder.java
@@ -41,8 +41,8 @@ class SourceRecordBuilder {
         ImmutableMap.of("deliveryTag", envelope.getDeliveryTag()),
         topic,
         null,
-        key.schema(),
-        key,
+        this.config.partitionKeyNull ? null : key.schema(),
+        this.config.partitionKeyNull ? null : key,
         value.schema(),
         value,
         null == basicProperties.getTimestamp() ? this.time.milliseconds() : basicProperties.getTimestamp().getTime()


### PR DESCRIPTION
MQ messageID will be queried as the Kafka message key, and if the messageID is null, then all the message will produce to only one broker. Although we can use transforms to form the key, but that will request a lot of effort to make thing right.
It will be good to have a nullable option.